### PR TITLE
Disable cursor transition when vim-mode editor focus is lost

### DIFF
--- a/stylesheets/ease-blink.less
+++ b/stylesheets/ease-blink.less
@@ -17,5 +17,6 @@
 }
 
 .vim-mode.editor:not(.is-focused) .cursors .cursor {
+  transition: opacity 0s ease;
   visibility: hidden;
 }


### PR DESCRIPTION
Addresses issue #3  
